### PR TITLE
background-icon (contact)

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -1670,6 +1670,7 @@ section:nth-child(odd) {
   height: 100%;
   top: -50px;
   padding-right: 30px;
+  z-index: -9999;
 }
 
 #contact .background-icon .fa {


### PR DESCRIPTION
z-index negativo aplicado a background-icon en la sección de contact para que este por debajo del enlace del email